### PR TITLE
Internals: Fail with clear error message if scripts not allowed by PS execuction policy (#2)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^revdep$
 ^Dockerfile$
 ^inst/medias$
+^dev_local

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 revdep
 Dockerfile
+dev_local

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: doconv
 Type: Package
 Title: Document Conversion to 'PDF' or 'PNG'
-Version: 0.3.2
+Version: 0.3.3.0001
 Authors@R: c(
     person("David", "Gohel", role = c("aut", "cre"),
     email = "david.gohel@ardata.fr"),
@@ -21,7 +21,7 @@ Description: It provides the ability to generate images from documents
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Imports: magick, pdftools, locatexec, processx, tools
 Depends: R (>= 4.0.0)
 Suggests: tinytest, testthat, webshot2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# doconv 0.3.3 (dev version)
+
+## Issues
+
+- Stop if PowerShell (PS) execution strategy does not allow running scripts and advise user. 
+  PS scripts are required for certain actions on Windows (#2). 
+
 # doconv 0.3.2
 
 ## Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,8 @@
 
 ## Issues
 
-- Stop if PowerShell (PS) execution strategy does not allow running scripts and advise user. 
-  PS scripts are required for certain actions on Windows (#2). 
+- Fail with informative error message if PowerShell (PS) execution strategy does not allow
+  running PS scripts. PS scripts are required for certain actions on Windows (#2).
 
 # doconv 0.3.2
 

--- a/R/docx2pdf.R
+++ b/R/docx2pdf.R
@@ -113,8 +113,6 @@ docx2pdf_win <- function(input, output = gsub("\\.(docx|doc|rtf)$", ".pdf", inpu
     stop("input does not exist", call. = FALSE)
   }
 
-  stop_on_wrong_ps_exec_policy()
-
   input <- absolute_path(input)
   output <- absolute_path(output)
 
@@ -129,11 +127,16 @@ docx2pdf_win <- function(input, output = gsub("\\.(docx|doc|rtf)$", ".pdf", inpu
   script_str[1] <- sprintf(script_str[1], input)
   script_str[2] <- sprintf(script_str[2], output_name)
   writeLines(script_str, script_path, useBytes = TRUE)
-
   res <- run("powershell", args = c("-file", script_path), error_on_status = FALSE)
+
   success <- res$status == 0
 
-  if(success) {
+  # fail with informative error if conversion fails due to PS Execution Policy
+  if (!success && grepl("UnauthorizedAccess", res$stderr)) {
+    stop_on_wrong_ps_exec_policy()
+  }
+
+  if (success) {
     success <- file.copy(from = output_name, to = output, overwrite = TRUE)
   }
 
@@ -217,8 +220,6 @@ docx_update_win <- function(input){
     stop("input does not exist", call. = FALSE)
   }
 
-  stop_on_wrong_ps_exec_policy()
-
   input <- absolute_path(input)
 
   init_working_directory()
@@ -233,7 +234,12 @@ docx_update_win <- function(input){
   res <- run("powershell", args = c("-file", script_path), error_on_status = FALSE)
   success <- res$status == 0
 
-  if(!success) stop("could not update ", input, call. = FALSE)
+  # fail with informative error if conversion fails due to PS Execution Policy
+  if (!success && grepl("UnauthorizedAccess", res$stderr)) {
+    stop_on_wrong_ps_exec_policy()
+  }
+
+  if (!success) stop("could not update ", input, call. = FALSE)
 
   success
 }
@@ -347,8 +353,6 @@ pptx2pdf_win <- function(input, output = gsub("\\.pptx$", ".pdf", input)){
     stop("input does not exist", call. = FALSE)
   }
 
-  stop_on_wrong_ps_exec_policy()
-
   input <- absolute_path(input)
   output <- absolute_path(output)
 
@@ -362,6 +366,11 @@ pptx2pdf_win <- function(input, output = gsub("\\.pptx$", ".pdf", input)){
 
   res <- run("powershell", args = c("-file", script_path), error_on_status = FALSE)
   success <- res$status == 0
+
+  # fail with informative error if conversion fails due to PS Execution Policy
+  if (!success && grepl("UnauthorizedAccess", res$stderr)) {
+    stop_on_wrong_ps_exec_policy()
+  }
 
   if(!success) stop("could not convert ", input, call. = FALSE)
 

--- a/R/docx2pdf.R
+++ b/R/docx2pdf.R
@@ -61,10 +61,10 @@ docx2pdf <- function(input, output = gsub("\\.(docx|doc|rtf)$", ".pdf", input)) 
   }
 }
 
+
 #' @importFrom locatexec is_osx
 #' @importFrom processx run
 docx2pdf_osx <- function(input, output = gsub("\\.(docx|doc|rtf)$", ".pdf", input)){
-
   if (!is_osx()) {
     stop("docx2pdf_osx() should only be used on 'macOS' systems.", call. = FALSE)
   }
@@ -101,6 +101,7 @@ docx2pdf_osx <- function(input, output = gsub("\\.(docx|doc|rtf)$", ".pdf", inpu
   output
 }
 
+
 #' @importFrom locatexec is_windows
 docx2pdf_win <- function(input, output = gsub("\\.(docx|doc|rtf)$", ".pdf", input)){
 
@@ -112,6 +113,8 @@ docx2pdf_win <- function(input, output = gsub("\\.(docx|doc|rtf)$", ".pdf", inpu
     stop("input does not exist", call. = FALSE)
   }
 
+  stop_on_wrong_ps_exec_policy()
+
   input <- absolute_path(input)
   output <- absolute_path(output)
 
@@ -120,8 +123,7 @@ docx2pdf_win <- function(input, output = gsub("\\.(docx|doc|rtf)$", ".pdf", inpu
 
   output_name <- file.path(default_root, gsub("\\.(docx|doc|rtf)$", ".pdf", basename(input)))
 
-  script_sourcefile <- system.file(
-    package = "doconv", "scripts", "powershell", "docx2pdf.ps1")
+  script_sourcefile <- system.file(package = "doconv", "scripts", "powershell", "docx2pdf.ps1")
   script_path <- tempfile(fileext = ".ps1")
   script_str <- readLines(script_sourcefile, encoding = "UTF-8")
   script_str[1] <- sprintf(script_str[1], input)
@@ -140,9 +142,8 @@ docx2pdf_win <- function(input, output = gsub("\\.(docx|doc|rtf)$", ".pdf", inpu
   if(!success) stop("could not convert ", input, res$stderr, call. = FALSE)
 
   output
-
-
 }
+
 
 #' @export
 #' @title Update docx fields
@@ -178,6 +179,7 @@ docx_update <- function(input) {
   invisible(x)
 }
 
+
 docx_update_osx <- function(input){
 
   if (!is_osx()) {
@@ -203,6 +205,8 @@ docx_update_osx <- function(input){
 
   success
 }
+
+
 docx_update_win <- function(input){
 
   if (!is_windows()) {
@@ -212,6 +216,8 @@ docx_update_win <- function(input){
   if (!file.exists(input)) {
     stop("input does not exist", call. = FALSE)
   }
+
+  stop_on_wrong_ps_exec_policy()
 
   input <- absolute_path(input)
 
@@ -231,10 +237,6 @@ docx_update_win <- function(input){
 
   success
 }
-
-
-
-
 
 
 #' @export
@@ -290,6 +292,7 @@ pptx2pdf <- function(input, output = gsub("\\.pptx$", ".pdf", input)) {
   }
 }
 
+
 #' @importFrom locatexec is_osx
 #' @importFrom processx run
 pptx2pdf_osx <- function(input, output = gsub("\\.pptx$", ".pdf", input)){
@@ -332,6 +335,7 @@ pptx2pdf_osx <- function(input, output = gsub("\\.pptx$", ".pdf", input)){
   output
 }
 
+
 #' @importFrom locatexec is_windows
 pptx2pdf_win <- function(input, output = gsub("\\.pptx$", ".pdf", input)){
 
@@ -342,6 +346,8 @@ pptx2pdf_win <- function(input, output = gsub("\\.pptx$", ".pdf", input)){
   if (!file.exists(input)) {
     stop("input does not exist", call. = FALSE)
   }
+
+  stop_on_wrong_ps_exec_policy()
 
   input <- absolute_path(input)
   output <- absolute_path(output)
@@ -359,8 +365,5 @@ pptx2pdf_win <- function(input, output = gsub("\\.pptx$", ".pdf", input)){
 
   if(!success) stop("could not convert ", input, call. = FALSE)
 
-  success
-
-
+  output
 }
-

--- a/R/expect_snapshot_doc.R
+++ b/R/expect_snapshot_doc.R
@@ -69,6 +69,7 @@ expect_snapshot_doc <- function(
 
 }
 
+
 #' @title Visual test for an HTML document
 #' @description This expectation can be used with 'tinytest' and 'testthat'
 #' to check if a current document of type HTML

--- a/R/to_pdf.R
+++ b/R/to_pdf.R
@@ -153,7 +153,7 @@ check_libreoffice_export <- function(UserInstallation = NULL) {
                "--outdir", default_root,
                input),
       error_on_status = FALSE,
-      timeout = 15
+      timeout = 45
       )
   success <- res$status == 0
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -145,11 +145,10 @@ images_to_miniature <- function(img_list, row = NULL, width = 650,
   img_stack
 }
 
-
 # get PS exec policy
 ps_execution_policy <- function() {
   res <- run("powershell", args = c("Get-ExecutionPolicy"), error_on_status = FALSE)
-  policy <- gsub("\\s+", "",  res$stdout)
+  policy <- gsub("\\s+", "", res$stdout)
   policy
 }
 
@@ -157,11 +156,12 @@ ps_execution_policy <- function() {
 # check if policy allows PS script execution. If not advise user.
 stop_on_wrong_ps_exec_policy <- function() {
   policy <- ps_execution_policy()
-  ps_exec_policies_ok <- c("RemoteSigned", "Bypass","Unrestricted")
-  if (!policy %in% ps_exec_policies_ok) {
-    stop("PowerShell execution policy '", policy, "' prevents script execution.\n",
-            "Run one of the following commands in PS as admin to allow script execution: \n",
-            "  `Set-ExecutionPolicy Bypass`\n",
-            "  `Set-ExecutionPolicy Unrestricted`\n", call. = FALSE)
-  }
+  ps_exec_policies_ok <- c("RemoteSigned", "Bypass", "Unrestricted")
+  stop("Conversion failed.\n",
+    "Your PowerShell execution policy '", policy, "' prevents script execution.\n",
+    "Run one of the following commands in PS as admin to enable script execution: \n",
+    "  `Set-ExecutionPolicy Bypass`\n",
+    "  `Set-ExecutionPolicy Unrestricted`\n",
+    call. = FALSE
+  )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -145,3 +145,23 @@ images_to_miniature <- function(img_list, row = NULL, width = 650,
   img_stack
 }
 
+
+# get PS exec policy
+ps_execution_policy <- function() {
+  res <- run("powershell", args = c("Get-ExecutionPolicy"), error_on_status = FALSE)
+  policy <- gsub("\\s+", "",  res$stdout)
+  policy
+}
+
+
+# check if policy allows PS script execution. If not advise user.
+stop_on_wrong_ps_exec_policy <- function() {
+  policy <- ps_execution_policy()
+  ps_exec_policies_ok <- c("RemoteSigned", "Bypass","Unrestricted")
+  if (!policy %in% ps_exec_policies_ok) {
+    stop("PowerShell execution policy '", policy, "' prevents script execution.\n",
+            "Run one of the following commands in PS as admin to allow script execution: \n",
+            "  `Set-ExecutionPolicy Bypass`\n",
+            "  `Set-ExecutionPolicy Unrestricted`\n", call. = FALSE)
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -156,7 +156,6 @@ ps_execution_policy <- function() {
 # check if policy allows PS script execution. If not advise user.
 stop_on_wrong_ps_exec_policy <- function() {
   policy <- ps_execution_policy()
-  ps_exec_policies_ok <- c("RemoteSigned", "Bypass", "Unrestricted")
   stop("Conversion failed.\n",
     "Your PowerShell execution policy '", policy, "' prevents script execution.\n",
     "Run one of the following commands in PS as admin to enable script execution: \n",


### PR DESCRIPTION
Fail with clear error message if PowerShell (PS) execution strategy does not allow running scripts in Windows (#2).

----

#### BEFORE

Reason for failure is unclear for user.

``` r
library(doconv)

file <- system.file(package = "doconv", "doc-examples/example.pptx")
out <- pptx2pdf(input = file, output = tempfile(fileext = ".pdf"))
#> Error: could not convert C:/Users/heckm/AppData/Local/R/win-library/4.4/doconv/doc-examples/example.pptx

file <- system.file(package = "doconv", "doc-examples/example.docx")
out <- docx2pdf(input = file, output = tempfile(fileext = ".pdf"))
#> Error: could not convert C:/Users/heckm/AppData/Local/R/win-library/4.4/doconv/doc-examples/example.docxDie Datei "C:\Users\heckm\AppData\Local\Temp\RtmpiSs1xl\file34605f593a78.ps1" kann nicht geladen werden, da die 
#> Ausfhrung von Skripts auf diesem System deaktiviert ist. Weitere Informationen finden Sie unter 
#> "about_Execution_Policies" (https:/go.microsoft.com/fwlink/?LinkID=135170).
#>     + CategoryInfo          : Sicherheitsfehler: (:) [], ParentContainsErrorRecordException
#>     + FullyQualifiedErrorId : UnauthorizedAccess

docx_out <- tempfile(fileext = ".docx")
file.copy(file, docx_out)
#> [1] TRUE
docx_update(input = docx_out)
#> Error: could not update C:/Users/heckm/AppData/Local/Temp/RtmpiSs1xl/file3460204023fd.docx
```

#### NEW

User is advised what to do.

``` r
library(doconv)

file <- system.file(package = "doconv", "doc-examples/example.pptx")
out <- pptx2pdf(input = file, output = tempfile(fileext = ".pdf"))
#> Error: Conversion failed.
#> Your PowerShell execution policy 'Restricted' prevents script execution.
#> Run one of the following commands in PS as admin to enable script execution: 
#>   `Set-ExecutionPolicy Bypass`
#>   `Set-ExecutionPolicy Unrestricted`

file <- system.file(package = "doconv", "doc-examples/example.docx")
out <- docx2pdf(input = file, output = tempfile(fileext = ".pdf"))
#> Error: Conversion failed.
#> Your PowerShell execution policy 'Restricted' prevents script execution.
#> Run one of the following commands in PS as admin to enable script execution: 
#>   `Set-ExecutionPolicy Bypass`
#>   `Set-ExecutionPolicy Unrestricted`

docx_out <- tempfile(fileext = ".docx")
file.copy(file, docx_out)
#> [1] TRUE
docx_update(input = docx_out)
#> Error: Conversion failed.
#> Your PowerShell execution policy 'Restricted' prevents script execution.
#> Run one of the following commands in PS as admin to enable script execution: 
#>   `Set-ExecutionPolicy Bypass`
#>   `Set-ExecutionPolicy Unrestricted`
```
<sup>Created on 2024-10-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
