### PR TITLE
feat: add show_markup parameter to docx2pdf() and to_miniature()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,9 @@
   easier page layout. `ncol` groups pages N-per-row; adding
   `ncol_landscape` enables orientation-aware layout where portrait and
   landscape pages use different column counts.
+- `docx2pdf()` and `to_miniature()` gain a `show_markup` parameter.
+  When `TRUE`, tracked changes and comments are rendered visibly in the
+  PDF output on Windows. Requires Microsoft Word.
 
 ## Issues
 

--- a/R/to_miniature.R
+++ b/R/to_miniature.R
@@ -36,6 +36,9 @@
 #' @param fileout if not NULL, result is saved in a png file whose filename
 #' is defined by this argument.
 #' @param dpi resolution (dots per inch) to use for images, see [pdftools::pdf_convert()].
+#' @param show_markup logical. If `TRUE`, tracked changes and comments
+#' are rendered visibly in the PDF output. Only effective for docx files
+#' on Windows (requires Microsoft Word). Default is `FALSE`.
 #' @param timeout timeout in seconds that libreoffice is allowed to use
 #' in order to generate the corresponding pdf file, ignored if 0.
 #' @param ... arguments used by webshot2 when HTML document.
@@ -60,6 +63,7 @@ to_miniature <- function(filename, row = NULL, ncol = NULL,
                          ncol_landscape = NULL, width = NULL,
                          border_color = "#ccc", border_geometry = "2x2",
                          dpi = 150,
+                         show_markup = FALSE,
                          fileout = NULL, timeout = 120,
                          ...) {
 
@@ -80,6 +84,7 @@ to_miniature <- function(filename, row = NULL, ncol = NULL,
       filename, row = row, ncol = ncol, ncol_landscape = ncol_landscape,
       width = width,
       border_color = border_color, border_geometry = border_geometry,
+      show_markup = show_markup,
       fileout = fileout, timeout = timeout)
   } else if(grepl("\\.pdf$", filename)){
     if(is.null(width)) width <- 650
@@ -127,11 +132,12 @@ pdf_to_miniature <- function(filename, row = NULL, ncol = NULL,
 docx_to_miniature <- function(filename, row = NULL, ncol = NULL,
                               ncol_landscape = NULL, width = 650,
                               border_color = "#ccc", border_geometry = "2x2",
+                              show_markup = FALSE,
                               fileout = NULL, dpi = 150, timeout = 120) {
   pdf_filename <- tempfile(fileext = ".pdf")
 
   if (exec_available("word")) {
-    docx2pdf(input = filename, output = pdf_filename)
+    docx2pdf(input = filename, output = pdf_filename, show_markup = show_markup)
   } else {
     to_pdf(input = filename, output = pdf_filename, timeout = timeout)
   }

--- a/inst/scripts/powershell/docx2pdf.ps1
+++ b/inst/scripts/powershell/docx2pdf.ps1
@@ -1,5 +1,6 @@
 $indocx = "%s"
 $opdf = "%s"
+$showMarkup = "%s"
 
 $Word = New-Object -ComObject Word.Application
 $Word.Visible = $False
@@ -10,6 +11,14 @@ try {
   foreach ($toc in $doc.TablesOfContents) { $toc.Update() }
   foreach ($toc in $doc.TablesOfFigures) { $toc.Update() }
 
+  if ($showMarkup -eq "True") {
+    $Word.ActiveWindow.View.ShowRevisionsAndComments = $true
+    $Word.ActiveWindow.View.RevisionsView = [Microsoft.Office.Interop.Word.WdRevisionsView]::wdRevisionsViewFinal
+    $exportItem = [Microsoft.Office.Interop.Word.WdExportItem]::wdExportDocumentWithMarkup
+  } else {
+    $exportItem = [Microsoft.Office.Interop.Word.WdExportItem]::wdExportDocumentContent
+  }
+
   $doc.ExportAsFixedFormat(
     $opdf,
     [Microsoft.Office.Interop.Word.WdExportFormat]::wdExportFormatPDF,
@@ -17,7 +26,7 @@ try {
     [Microsoft.Office.Interop.Word.WdExportOptimizeFor]::wdExportOptimizeForPrint,
     [Microsoft.Office.Interop.Word.WdExportRange]::wdExportAllDocument,
     0, 0,
-    [Microsoft.Office.Interop.Word.WdExportItem]::wdExportDocumentContent,
+    $exportItem,
     $true, $false,
     [Microsoft.Office.Interop.Word.WdExportCreateBookmarks]::wdExportCreateWordBookmarks,
     $true, $false, $true

--- a/man/docx2pdf.Rd
+++ b/man/docx2pdf.Rd
@@ -4,11 +4,20 @@
 \alias{docx2pdf}
 \title{Convert docx to pdf}
 \usage{
-docx2pdf(input, output = gsub("\\\\.(docx|doc|rtf)$", ".pdf", input))
+docx2pdf(
+  input,
+  output = gsub("\\\\.(docx|doc|rtf)$", ".pdf", input),
+  show_markup = FALSE
+)
 }
 \arguments{
 \item{input, output}{file input and optional file output (default
 to input with pdf extension).}
+
+\item{show_markup}{logical. If \code{TRUE}, tracked changes and comments
+are rendered visibly in the PDF output. Only supported on Windows;
+on macOS a warning is issued and the parameter is ignored.
+Default is \code{FALSE}.}
 }
 \value{
 the name of the produced pdf (the same value as \code{output})

--- a/man/to_miniature.Rd
+++ b/man/to_miniature.Rd
@@ -13,6 +13,7 @@ to_miniature(
   border_color = "#ccc",
   border_geometry = "2x2",
   dpi = 150,
+  show_markup = FALSE,
   fileout = NULL,
   timeout = 120,
   ...
@@ -55,6 +56,10 @@ When set, portrait pages use \code{ncol} per row and landscape pages use
 images, see \code{\link[magick:composite]{magick::image_border()}}.}
 
 \item{dpi}{resolution (dots per inch) to use for images, see \code{\link[pdftools:pdf_render_page]{pdftools::pdf_convert()}}.}
+
+\item{show_markup}{logical. If \code{TRUE}, tracked changes and comments
+are rendered visibly in the PDF output. Only effective for docx files
+on Windows (requires Microsoft Word). Default is \code{FALSE}.}
 
 \item{fileout}{if not NULL, result is saved in a png file whose filename
 is defined by this argument.}


### PR DESCRIPTION
## Summary

- New `show_markup` parameter (default `FALSE`) for `docx2pdf()` and `to_miniature()`
- When `TRUE`, tracked changes and comments are rendered visibly in the PDF output
- Implemented via Word COM's `WdExportItem::wdExportDocumentWithMarkup` and `ShowRevisionsAndComments`
- On macOS, the parameter is accepted but ignored (with a warning), since AppleScript's PDF export does not support markup rendering

## Files changed

| File | Change |
|------|--------|
| `inst/scripts/powershell/docx2pdf.ps1` | New `$showMarkup` variable; conditional markup view + dynamic `$exportItem` |
| `R/docx2pdf.R` | `show_markup` param in `docx2pdf()`, `docx2pdf_win()`, `docx2pdf_osx()` |
| `R/to_miniature.R` | `show_markup` param in `to_miniature()` and `docx_to_miniature()` |
| `man/docx2pdf.Rd` | Regenerated |
| `man/to_miniature.Rd` | Regenerated |
| `NEWS.md` | Feature entry |

## Test

Tested manually on Windows 11 with Microsoft Word — a DOCX containing tracked changes and comments produces visually different PNGs with `show_markup = TRUE` vs `FALSE`.